### PR TITLE
Send content-type header when creating tasks

### DIFF
--- a/tes/client.py
+++ b/tes/client.py
@@ -47,6 +47,7 @@ class HTTPClient(object):
         response = requests.post(
             "%s/v1/tasks" % (self.url),
             data=msg,
+            headers={'Content-Type': 'application/json'},
             timeout=self.timeout
         )
         raise_for_status(response)


### PR DESCRIPTION
Since the swagger specification for TES states

```
  "consumes": [
    "application/json"
],
```

It can be interpreted that a TES server may reject anything that it's not json.
Removing the ambiguity with a content-type header makes this client compatible with those servers.