### PR TITLE
feat: pass through json serialization options

### DIFF
--- a/tes/models.py
+++ b/tes/models.py
@@ -94,10 +94,11 @@ class Base(object):
             return _drop_none(obj)
         return obj
 
-    def as_json(self, drop_empty=True):
+    def as_json(self, drop_empty=True, **kwargs):
         return json.dumps(
             self.as_dict(drop_empty),
-            default=datetime_json_handler
+            default=datetime_json_handler,
+            **kwargs
         )
 
 


### PR DESCRIPTION
Pass through arbitrary keyword arguments to `json.dumps()` in the [`Base.as_json()`](https://github.com/ohsu-comp-bio/py-tes/blob/a9ac2959fdb38bd31433d358724e20c2c544c6a1/tes/models.py#L97-L101) method.

Among other things, this can be used to "pretty print" a model (see #21), like so:

```python
import tes

task = tes.Task(
    executors=[
        tes.Executor(
            image="alpine",
            command=["echo", "hello"]
        )
    ]
)

print(task.as_json(indent=3))
```

Output:

```console
{
   "executors": [
      {
         "image": "alpine",
         "command": [
            "echo",
            "hello"
         ]
      }
   ]
}
```

Resolves #21