### PR TITLE
test: increase unit test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,9 @@ jobs:
         run: flake8 .
 
       - name: Run unit tests
-        run: coverage run --source tes -m pytest -W ignore::DeprecationWarning
+        run: |
+          pytest \
+            --cov=tes/ \
+            --cov-branch \
+            --cov-report=term-missing \
+            --cov-fail-under=99

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: pip install .
 
       - name: Lint with Flake8
-        run: flake8 .
+        run: flake8 --max-line-length=120 .
 
       - name: Run unit tests
         run: |

--- a/tes/client.py
+++ b/tes/client.py
@@ -120,14 +120,14 @@ class HTTPClient(object):
             time.sleep(0.5)
 
     def _request_params(
-        self, data: Optional[str] = None,
-        params: Optional[Dict] = None
+        self, data: Optional[str] = None, params: Optional[Dict] = None
     ) -> Dict[str, Any]:
         kwargs: Dict[str, Any] = {}
         kwargs['timeout'] = self.timeout
         kwargs['headers'] = {}
         kwargs['headers']['Content-type'] = 'application/json'
-        kwargs['auth'] = (self.user, self.password)
+        if self.user is not None and self.password is not None:
+            kwargs['auth'] = (self.user, self.password)
         if data:
             kwargs['data'] = data
         if params:

--- a/tes/models.py
+++ b/tes/models.py
@@ -10,19 +10,15 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 
-@attrs
+@attrs(repr=False)
 class _ListOfValidator(object):
     type: Type = attrib()
 
-    def __call__(self, inst, attr, value):
-        """
-        We use a callable class to be able to change the ``__repr__``.
-        """
+    def __call__(self, inst, attr, value) -> None:
         if not all([isinstance(n, self.type) for n in value]):
             raise TypeError(
-                "'{attr.name}' must be a list of {self.type!r} (got {value!r} "
-                "that is a list of {values[0].__class__!r}).",
-                attr, self.type, value,
+                f"'{attr.name}' must be a list of {self.type!r} (got "
+                f"{value!r}", attr
             )
 
     def __repr__(self) -> str:
@@ -60,15 +56,15 @@ def strconv(value: Any) -> Any:
 # since an int64 value is encoded as a string in json we need to handle
 # conversion
 def int64conv(value: Optional[str]) -> Optional[int]:
-    if value is not None:
-        return int(value)
-    return value
+    if value is None:
+        return value
+    return int(value)
 
 
 def timestampconv(value: Optional[str]) -> Optional[datetime]:
-    if value is not None:
-        return dateutil.parser.parse(value)
-    return value
+    if value is None:
+        return value
+    return dateutil.parser.parse(value)
 
 
 def datetime_json_handler(x: Any) -> str:
@@ -294,7 +290,7 @@ class Task(Base):
             for e in self.executors:
                 if e.image is None:
                     errs.append("Executor image must be provided")
-                if len(e.command) == 0:
+                if e.command is None or len(e.command) == 0:
                     errs.append("Executor command must be provided")
                 if e.stdin is not None:
                     if not os.path.isabs(e.stdin):
@@ -306,8 +302,8 @@ class Task(Base):
                     if not os.path.isabs(e.stderr):
                         errs.append("Executor stderr must be an absolute path")
                 if e.env is not None:
-                    for k, v in e.env:
-                        if not isinstance(k, str) and not isinstance(k, str):
+                    for k, v in e.env.items():
+                        if not isinstance(k, str) and not isinstance(v, str):
                             errs.append(
                                 "Executor env keys and values must be StrType"
                             )
@@ -339,7 +335,7 @@ class Task(Base):
                         errs.append("Volume paths must be absolute")
 
         if self.tags is not None:
-            for k, v in self.tags:
+            for k, v in self.tags.items():
                 if not isinstance(k, str) and not isinstance(k, str):
                     errs.append(
                         "Tag keys and values must be StrType"

--- a/tes/utils.py
+++ b/tes/utils.py
@@ -27,14 +27,20 @@ class TimeoutError(Exception):
 
 
 def unmarshal(j: Any, o: Type, convert_camel_case=True) -> Any:
+    m: Any = None
     if isinstance(j, str):
-        m = json.loads(j)
-    elif isinstance(j, dict):
-        m = j
+        try:
+            m = json.loads(j)
+        except json.decoder.JSONDecodeError:
+            pass
     elif j is None:
         return None
     else:
-        raise TypeError("j must be a str, a dict or None")
+        m = j
+
+    if not isinstance(m, dict):
+        raise TypeError("j must be a dictionary, a JSON string evaluation to "
+                        "a dictionary, or None")
 
     d: Dict[str, Any] = {}
     if convert_camel_case:
@@ -77,16 +83,8 @@ def unmarshal(j: Any, o: Type, convert_camel_case=True) -> Any:
         field = v
         omap = fullOmap.get(o.__name__, {})
         if k in omap:
-            if isinstance(omap[k], tuple):
-                try:
-                    obj = omap[k][0]
-                    field = _unmarshal(v, obj)
-                except Exception:
-                    obj = omap[k][1]
-                    field = _unmarshal(v, obj)
-            else:
-                obj = omap[k]
-                field = _unmarshal(v, obj)
+            obj = omap[k]
+            field = _unmarshal(v, obj)
         r[k] = field
 
     try:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,5 @@ coverage>=6.5.0
 coveralls>=3.3.1
 flake8>=5.0.4
 pytest>=7.2.1
+pytest-cov>=4.0.0
 requests_mock>=1.10.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,67 +1,250 @@
 import json
 import unittest
 
-from tes.models import Task, Executor, Input, Output, strconv
+from copy import deepcopy
+
+from tes.models import (
+    Executor,
+    ExecutorLog,
+    Input,
+    Output,
+    OutputFileLog,
+    Resources,
+    Task,
+    TaskLog,
+    datetime_json_handler,
+    int64conv,
+    list_of,
+    strconv,
+    timestampconv,
+    _drop_none,
+)
+
+
+task_valid = Task(
+    executors=[
+        Executor(
+            image="alpine",
+            command=["echo", "hello"]
+        )
+    ]
+)
+
+
+datetm = "2018-01-01T00:00:00Z"
+task_valid_full = Task(
+    id="foo",
+    state="COMPLETE",
+    name="some_task",
+    description="some description",
+    resources=Resources(
+        cpu_cores=1,
+        ram_gb=2,
+        disk_gb=3,
+        preemptible=True,
+        zones=["us-east-1", "us-west-1"],
+    ),
+    executors=[
+        Executor(
+            image="alpine",
+            command=["echo", "hello"],
+            workdir="/abs/path",
+            stdin="/abs/path",
+            stdout="/abs/path",
+            stderr="/abs/path",
+            env={"VAR": "value"}
+        ),
+        Executor(
+            image="alpine",
+            command=["echo", "worls"]
+        )
+    ],
+    inputs=[
+        Input(
+            url="s3:/some/path",
+            path="/abs/path"
+        ),
+        Input(
+            content="foo",
+            path="/abs/path"
+        )
+    ],
+    outputs=[
+        Output(
+            url="s3:/some/path",
+            path="/abs/path"
+        )
+    ],
+    volumes=[],
+    tags={"key": "value", "key2": "value2"},
+    logs=[
+        TaskLog(
+            start_time=datetm,  # type: ignore
+            end_time=datetm,  # type: ignore
+            metadata={"key": "value", "key2": "value2"},
+            logs=[
+                ExecutorLog(
+                    start_time=datetm,  # type: ignore
+                    end_time=datetm,  # type: ignore
+                    exit_code=0,
+                    stdout="hello",
+                    stderr="world"
+                )
+            ],
+            outputs=[
+                OutputFileLog(
+                    url="s3:/some/path",
+                    path="/abs/path",
+                    size_bytes=int64conv(123)  # type: ignore
+                )
+            ],
+            system_logs=[
+                "some system log message",
+                "some other system log message"
+            ]
+        )
+    ],
+    creation_time=datetm  # type: ignore
+)
+
+task_invalid = Task(
+    executors=[
+        Executor(  # type: ignore
+            image="alpine",
+            command=["echo", "hello"],
+            stdin="relative/path",
+            stdout="relative/path",
+            stderr="relative/path",
+            env={1: 2}
+        )
+    ],
+    inputs=[
+        Input(
+            url="s3:/some/path",
+            content="foo"
+        ),
+        Input(
+            path="relative/path"
+        )
+    ],
+    outputs=[
+        Output(),
+        Output(
+            url="s3:/some/path",
+            path="relative/path"
+        )
+    ],
+    volumes=['/abs/path', 'relative/path'],
+    tags={1: 2}
+)
+
+expected = {
+    "executors": [
+        {
+            "image": "alpine",
+            "command": ["echo", "hello"]
+        }
+    ]
+}
 
 
 class TestModels(unittest.TestCase):
-    task = Task(
-        executors=[
-            Executor(
-                image="alpine",
-                command=["echo", "hello"]
-            )
-        ]
-    )
-
-    expected = {
-        "executors": [
-            {
-                "image": "alpine",
-                "command": ["echo", "hello"]
-            }
-        ]
-    }
-
-    def test_strconv(self):
-        self.assertTrue(strconv("foo"), u"foo")
-        self.assertTrue(strconv(["foo", "bar"]), [u"foo", u"bar"])
-        self.assertTrue(strconv(("foo", "bar")), (u"foo", u"bar"))
-        self.assertTrue(strconv(1), 1)
-
-        with self.assertRaises(TypeError):
-            Input(
-                url="s3:/some/path", path="/opt/foo", content=123
-            )
 
     def test_list_of(self):
+        validator = list_of(str)
+        self.assertEqual(list_of(str), validator)
+        self.assertEqual(
+            repr(validator),
+            "<instance_of validator for type <class 'str'>>"
+        )
+        with self.assertRaises(TypeError):
+            Input(
+                url="s3:/some/path",
+                path="/opt/foo",
+                content=123  # type: ignore
+            )
         with self.assertRaises(TypeError):
             Task(
                 inputs=[
                     Input(
                         url="s3:/some/path", path="/opt/foo"
                     ),
-                    "foo"
+                    "foo"  # type: ignore
                 ]
             )
 
+    def test_drop_none(self):
+        self.assertEqual(_drop_none({}), {})
+        self.assertEqual(_drop_none({"foo": None}), {})
+        self.assertEqual(_drop_none({"foo": 1}), {"foo": 1})
+        self.assertEqual(_drop_none({"foo": None, "bar": 1}), {"bar": 1})
+        self.assertEqual(_drop_none({"foo": [1, None, 2]}), {"foo": [1, 2]})
+        self.assertEqual(_drop_none({"foo": {"bar": None}}), {"foo": {}})
+        self.assertEqual(
+            _drop_none({"foo": {"bar": None}, "baz": 1}),
+            {"foo": {}, "baz": 1}
+        )
+
+    def test_strconv(self):
+        self.assertTrue(strconv("foo"), u"foo")
+        self.assertTrue(strconv(["foo", "bar"]), [u"foo", u"bar"])
+        self.assertTrue(strconv(("foo", "bar")), (u"foo", u"bar"))
+        self.assertTrue(strconv(1), 1)
+        self.assertTrue(strconv([1]), [1])
+
+    def test_int64conv(self):
+        self.assertEqual(int64conv("1"), 1)
+        self.assertEqual(int64conv("-1"), -1)
+        self.assertIsNone(int64conv(None))
+
+    def test_timestampconv(self):
+        tm = timestampconv("2018-02-01T00:00:00Z")
+        self.assertIsNotNone(tm)
+        assert tm is not None
+        self.assertAlmostEqual(tm.year, 2018)
+        self.assertAlmostEqual(tm.month, 2)
+        self.assertAlmostEqual(tm.day, 1)
+        self.assertAlmostEqual(tm.hour, 0)
+        self.assertAlmostEqual(tm.timestamp(), 1517443200.0)
+        self.assertIsNone(timestampconv(None))
+
+    def test_datetime_json_handler(self):
+        tm = timestampconv("2018-02-01T00:00:00Z")
+        tm_iso = '2018-02-01T00:00:00+00:00'
+        assert tm is not None
+        self.assertEqual(datetime_json_handler(tm), tm_iso)
+        with self.assertRaises(TypeError):
+            datetime_json_handler(None)
+        with self.assertRaises(TypeError):
+            datetime_json_handler("abc")
+        with self.assertRaises(TypeError):
+            datetime_json_handler(2001)
+        with self.assertRaises(TypeError):
+            datetime_json_handler(tm_iso)
+
     def test_as_dict(self):
-        self.assertEqual(self.task.as_dict(), self.expected)
+        task = deepcopy(task_valid)
+        self.assertEqual(task.as_dict(), expected)
+        with self.assertRaises(KeyError):
+            task.as_dict()['inputs']
+        self.assertIsNone(task.as_dict(drop_empty=False)['inputs'])
 
     def test_as_json(self):
-        self.assertEqual(self.task.as_json(), json.dumps(self.expected))
+        task = deepcopy(task_valid)
+        self.assertEqual(task.as_json(), json.dumps(expected))
 
     def test_is_valid(self):
-        self.assertTrue(self.task.is_valid()[0])
+        task = deepcopy(task_valid)
+        self.assertTrue(task.is_valid()[0])
 
-        task2 = self.task
-        task2.inputs = [Input(path="/opt/foo")]
-        self.assertFalse(task2.is_valid()[0])
+        task = deepcopy(task_valid_full)
+        self.assertTrue(task.is_valid()[0])
 
-        task3 = self.task
-        task3.outputs = [
-            Output(
-                url="s3:/some/path", path="foo"
-            )
-        ]
-        self.assertFalse(task3.is_valid()[0])
+        task = deepcopy(task_invalid)
+        task.executors[0].image = None  # type: ignore
+        task.executors[0].command = None  # type: ignore
+        self.assertFalse(task.is_valid()[0])
+
+        task = deepcopy(task_invalid)
+        task.executors = None
+        self.assertFalse(task.is_valid()[0])


### PR DESCRIPTION
* Increase unit test coverage both from the point of view of covering more reaslistic scenarios and from the point of view of covering more code statements
* Code coverage now at >99%, with the only missing statements in an unused function that may be removed (see #48 and #50)
* Replace `unittest`'s deprecated `.assertEquals()` and `.assertAlmostEquals()` calls with `.assertEqual()` and `.assertAlmostEqual`
* Do not add `auth` as parameter to `requests` if `user` and/or `password` are not specified (accepting `None` for these is [deprecated from `requests 3.0.0`](https://github.com/psf/requests/blob/15585909c3dd3014e4083961c8a404709450151c/requests/auth.py#L28-L54))
* Remove several code smells/minor bugs along the process (see comments in proposed code changes)
* Replace test call in CI workflow to use `pytest-cov` (now in `tests/requirements.txt`), along with the branch testing flag `--cov-branch` switched on and the `--cov-fail-under` option set to 99 (can be changed to 100, once #50 is merged or tests are provided for the missing statement in `tes.client.HTTPClient.wait()`)

Resolves #47