### PR TITLE
Remove unused future dependency (again)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 attrs>=17.4.0
-future>=0.16.0
 python-dateutil>=2.6.1
 requests>=2.18.2
 sphinx_rtd_theme


### PR DESCRIPTION
See https://github.com/ohsu-comp-bio/py-tes/pull/61. While that PR was merged, it ended up having no effect because a [commit merged back from `master`](3e4230d2f97bbc1b6b310f8bc364ed0abafdf56f) reintroduced the `future` dependency to `requirements.txt`.