### PR TITLE
Fixes to avoid unmarshalling errors in some corner cases dealing with TES 1.1 compliant service

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,12 @@ jobs:
         #   - "1.0"
         #   - "1.1"
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Check out code

--- a/tes/models.py
+++ b/tes/models.py
@@ -221,7 +221,7 @@ class Resources(Base):
         default=None, converter=strconv, validator=optional(list_of(str))
     )
     backend_parameters: Optional[Dict[str, str]] = attrib(
-        default=None, validator=optional(instance_of(map))
+        default=None, validator=optional(instance_of(dict))
     )
     backend_parameters_strict: Optional[bool] = attrib(
         default=None, validator=optional(instance_of(bool))

--- a/tes/models.py
+++ b/tes/models.py
@@ -221,7 +221,7 @@ class Resources(Base):
         default=None, converter=strconv, validator=optional(list_of(str))
     )
     backend_parameters: Optional[Dict[str, str]] = attrib(
-        default=None, converter=strconv, validator=optional(instance_of(map))
+        default=None, validator=optional(instance_of(map))
     )
     backend_parameters_strict: Optional[bool] = attrib(
         default=None, validator=optional(instance_of(bool))

--- a/tes/models.py
+++ b/tes/models.py
@@ -187,6 +187,9 @@ class Output(Base):
     path: Optional[str] = attrib(
         default=None, converter=strconv, validator=optional(instance_of(str))
     )
+    path_prefix: Optional[str] = attrib(
+        default=None, converter=strconv, validator=optional(instance_of(str))
+    )
     type: str = attrib(
         default="FILE", validator=in_(["FILE", "DIRECTORY"])
     )
@@ -333,8 +336,19 @@ class Task(Base):
     state: Optional[str] = attrib(
         default=None,
         validator=optional(in_(
-            ["UNKNOWN", "QUEUED", "INITIALIZING", "RUNNING", "COMPLETE",
-             "CANCELED", "EXECUTOR_ERROR", "SYSTEM_ERROR"]
+            [
+                "UNKNOWN",
+                "QUEUED",
+                "INITIALIZING",
+                "RUNNING",
+                "PAUSED",
+                "COMPLETE",
+                "EXECUTOR_ERROR",
+                "SYSTEM_ERROR",
+                "CANCELED",
+                "CANCELING",
+                "PREEMPTED",
+            ]
         ))
     )
     name: Optional[str] = attrib(

--- a/tes/models.py
+++ b/tes/models.py
@@ -220,8 +220,8 @@ class Resources(Base):
     zones: Optional[List[str]] = attrib(
         default=None, converter=strconv, validator=optional(list_of(str))
     )
-    backend_parameters: Optional[List[str]] = attrib(
-        default=None, converter=strconv, validator=optional(instance_of(list))
+    backend_parameters: Optional[Dict[str, str]] = attrib(
+        default=None, converter=strconv, validator=optional(instance_of(map))
     )
     backend_parameters_strict: Optional[bool] = attrib(
         default=None, validator=optional(instance_of(bool))


### PR DESCRIPTION
This pull request has several fixes to avoid unmarshalling errors in some corner cases dealing with TES 1.1 compliant service.

This pull request fixes issue described at #74 