### PR TITLE
fix: Integration Tests in tests.yml (Funnel install)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -26,7 +26,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: python-package-distributions
         path: dist/
@@ -46,12 +46,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
@@ -69,12 +69,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Linting and testing
 
-on: [pull_request]
+on:
+  - push
 
 jobs:
   test:
@@ -9,19 +10,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Handle multiple TES versions here, currently we're only testing against TES 1.1
-        # - py-tes v1.0 — TES 1.0
-        # - py-tes v1.1 — TES 1.1
-        # tes-version:
-        #   - "1.0"
-        #   - "1.1"
+        tes-version:
+          - "1.0"
+          - "1.1"
+        
+        # Only using Supported Python versions here:
+        # https://devguide.python.org/versions
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
+          - "3.15"
 
     steps:
       - name: Check out code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,13 +17,16 @@ jobs:
         
         # Only using Supported Python versions here:
         # https://devguide.python.org/versions
+        #
+        # Available Versions:
+        # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         python-version:
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
           - "3.14"
-          - "3.15"
+          - "3.15.0-beta.1"
 
     steps:
       - name: Check out code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,13 +52,33 @@ jobs:
             --cov-fail-under=99 \
             --ignore=tests/integration
 
+      # Note: Using the same install steps here as in nf-ga4gh plugin
+      # https://github.com/nextflow-io/nf-ga4gh/blob/1.4.1/.github/workflows/build.yml#L78-L101
+      - name: Install TES Server
+        run: |
+          # Pinning install script below to stable commit for security/reproducibility
+          # Ref: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
+          # Release: https://github.com/calypr/funnel/releases/tag/v0.11.8
+
+          INSTALL_SCRIPT=https://raw.githubusercontent.com/calypr/funnel/4103475e492dec1fd853e9863d0caad15fc504c0/install.sh
+          curl -fsSL $INSTALL_SCRIPT | bash -s -- v0.11.8
+
+      - name: Start TES Server
+        run: |
+          set -euo pipefail
+          nohup funnel server run > funnel.log 2>&1 &
+          echo $! > funnel.pid
+          for i in $(seq 1 10); do
+            if curl -fsS http://localhost:8000/service-info >/dev/null 2>&1; then
+              echo "Funnel server started"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Funnel server failed to start!"
+          cat funnel.log
+          exit 1
+
       - name: Run integration tests
         run: |
-          /bin/bash -c "$(curl -fsSL https://github.com/calypr/funnel/releases/latest/download/install.sh)"
-          funnel --version
-          funnel server --LocalStorage.AllowedDirs $HOME run &
-          for i in $(seq 1 20); do
-+            curl -fsS http://localhost:8000/ga4gh/tes/v1/service-info && break
-+            sleep 1
-+          done
           pytest tests/integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   test:
+    name: test (TES ${{ matrix.tes-version }}, Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -26,10 +27,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ attrs>=17.4.0
 python-dateutil>=2.6.1
 requests>=2.18.2
 sphinx_rtd_theme
+pytest
+

--- a/tes/models.py
+++ b/tes/models.py
@@ -108,8 +108,8 @@ def timestampconv(value: Optional[str]) -> Optional[datetime]:
     Returns:
         Converted value.
     """
-    if value is None:
-        return value
+    if not value:
+        return None
     if isinstance(value, datetime):
         return value
     return dateutil.parser.parse(value)

--- a/tes/models.py
+++ b/tes/models.py
@@ -493,7 +493,7 @@ class Organization:
 
 
 @attrs
-class Type:
+class ServiceType:
     artifact: Optional[str] = attrib(
         default=None, converter=strconv, validator=optional(instance_of(str))
     )


### PR DESCRIPTION
# Overview

This PR includes several improvements to the GitHub Action tests:

- Updates Funnel's install steps in [`test.yml`](https://github.com/calypr/py-tes/pull/78/changes#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR60-R86)
- Pins Actions to latest commits for security + reproducibility
- Re-enables TES 1.0 tests (alongside TES 1.1) in [`tests.yml`](https://github.com/calypr/py-tes/pull/78/changes#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR60-R86)
- Minor type updates to support Python 3.14 in [models.py](https://github.com/calypr/py-tes/pull/78/changes#diff-93a7e24355e16daa9914541968cebb2982316956535d55f0768bdbd39b5de804)