### PR TITLE
`fix/test-before-publish` → `main`: Ensure tests are run before releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,19 @@
 
 name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  workflow_run:
+    workflows:
+      - "Linting and testing"
+    types:
+      - completed
+    branches:
+      - "refs/tags/**"
 
 jobs:
   build:
     name: Build distribution 📦
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'refs/tags/')
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +42,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: startsWith(github.event.workflow_run.head_branch, 'refs/tags/')
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Overview 🌀

This PR updates `publish.yml` to create new releases on PyPi + GitHub only after the "Linting and testing" workflow (`tests.yml`) has run successfully.

## Current Behavior ⚠️

Releases are made as soon as a new tag is pushed, as `test.yml` and `publish.yml` are essentially "decoupled" and run in parallel.

> [!WARNING]
> 
> For example, version [0.1.3](https://github.com/calypr/py-tes/actions/runs/26316044288) was released even though the [linting job](https://github.com/calypr/py-tes/actions/runs/26316044274) failed.
> 
> This job was [resolved](https://github.com/calypr/py-tes/actions/runs/26316112896) manually as part of the version [0.1.4](https://github.com/calypr/py-tes/actions/runs/26316112856) release (but should be automated).

## New Behavior ✔️

Releases are made as soon as a new tag is pushed **and** tests complete successfully.

`test.yml` and `publish.yml` now run sequentially.

## Breaking Changes? ❌

- [x] None expected, simply an update to how GitHub Action tests are run!